### PR TITLE
Fix invalid JSON

### DIFF
--- a/META.info
+++ b/META.info
@@ -5,7 +5,7 @@
   "provides": {
     "Pekyll"            : "lib/Pekyll.pm6",
     "Pekyll::Routers"   : "lib/Pekyll/Routers.pm6",
-    "Pekyll::Compilers" : "lib/Pekyll/Compilers.pm6",
+    "Pekyll::Compilers" : "lib/Pekyll/Compilers.pm6"
   },
   "depends"     : [ "Template6", "Syndication" ],
   "source-url"  : "git://github.com/nunorc/p6-Pekyll"


### PR DESCRIPTION
META.info must be valid JSON, which doesn't allow trailing commas :smile_cat: 
