### PR TITLE
Fix removed @*INC

### DIFF
--- a/t/01-simple.t
+++ b/t/01-simple.t
@@ -2,7 +2,7 @@ use v6;
 use Test;
 plan 4;
 
-#BEGIN { @*INC.unshift: './lib'; }
+# use lib 'lib';
 
 use-ok("Pekyll");
 use-ok("Pekyll::Routers");


### PR DESCRIPTION
@*INC is no longer available. `use lib` is the new way.
